### PR TITLE
Fixing child process concurrency issue

### DIFF
--- a/execution/command_execution_utils.c
+++ b/execution/command_execution_utils.c
@@ -6,7 +6,7 @@
 /*   By: aldokezer <aldokezer@student.42.fr>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/17 10:47:04 by aldokezer         #+#    #+#             */
-/*   Updated: 2024/04/18 11:45:18 by aldokezer        ###   ########.fr       */
+/*   Updated: 2024/04/18 21:33:17 by aldokezer        ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,7 +47,6 @@ char	*ft_extract_env_name(char *str)
 	return (env_name);
 }
 
-
 /**
  * @brief Updates the shell's exit status.
  *
@@ -68,6 +67,7 @@ void	ft_update_exit_status(int *status, t_mini_data *minidata)
 	char	*sta;
 	char	*env;
 	char	*temp;
+
 	if (WIFEXITED(*status))
 		sta = ft_itoa(WEXITSTATUS(*status));
 	else
@@ -95,10 +95,23 @@ void	ft_update_exit_status(int *status, t_mini_data *minidata)
 void	ft_parent_process(t_exec_data *data, t_mini_data *minidata, pid_t pid)
 {
 	int	status;
+	int	i;
+	int	term_sig;
 
 	status = 0;
-	waitpid(pid, &status, 0);
-	ft_update_exit_status(&status, minidata);
+	i = 0;
+	while (i < data->num_children)
+	{
+		waitpid(data->child_pids[i], &status, 0);
+		if (WIFSIGNALED(status))
+		{
+			term_sig = WTERMSIG(status);
+			status = 128 + term_sig;
+		}
+		ft_update_exit_status(&status, minidata);
+		i++;
+	}
+	free(data->child_pids);
 	close(data->ori_fd_in);
 	close(data->ori_fd_out);
 }
@@ -113,12 +126,16 @@ void	ft_parent_process(t_exec_data *data, t_mini_data *minidata, pid_t pid)
  * @param exec_data Pointer to the execution data structure to initialize.
  */
 
-void	ft_init_exec_data(t_exec_data *exec_data)
+void	ft_init_exec_data(t_exec_data *exec_data, t_cmd_tab *tab)
 {
 	exec_data->fd_in = STDIN_FILENO;
 	exec_data->fd_out = STDOUT_FILENO;
 	exec_data->ori_fd_in = dup(STDIN_FILENO);
 	exec_data->ori_fd_out = dup(STDOUT_FILENO);
+	exec_data->num_commands = tab->size;
+	exec_data->num_children = 0;
+	exec_data->child_pids = malloc(sizeof(pid_t) * exec_data->num_commands);
+	exec_data->cmd = tab->first_cmd;
 }
 
 /**
@@ -136,6 +153,5 @@ void	ft_exit_status(int *status)
 	{
 		ft_putnbr_fd(WEXITSTATUS(*status), 1);
 		ft_putstr_fd("\n", 1);
-
 	}
 }

--- a/execution/command_execution_utils.c
+++ b/execution/command_execution_utils.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   command_execution_utils.c                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: mbartos <mbartos@student.42prague.com>     +#+  +:+       +#+        */
+/*   By: aldokezer <aldokezer@student.42.fr>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/17 10:47:04 by aldokezer         #+#    #+#             */
-/*   Updated: 2024/04/15 10:01:49 by mbartos          ###   ########.fr       */
+/*   Updated: 2024/04/18 11:45:18 by aldokezer        ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 

--- a/execution/pre_process_execution.c
+++ b/execution/pre_process_execution.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   pre_process_execution.c                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: mbartos <mbartos@student.42prague.com>     +#+  +:+       +#+        */
+/*   By: aldokezer <aldokezer@student.42.fr>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/21 09:19:32 by aldokezer         #+#    #+#             */
-/*   Updated: 2024/03/29 11:08:05 by mbartos          ###   ########.fr       */
+/*   Updated: 2024/04/18 20:38:30 by aldokezer        ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -75,7 +75,7 @@ int	ft_pre_exec(t_cmd_tab *tab, t_mini_data *minidata)
 	t_cmd		*cmd;
 	t_env_list	*envs;
 
-	ft_init_exec_data(&data);
+	ft_init_exec_data(&data, tab);
 	cmd = tab->first_cmd;
 	envs = minidata->env_list;
 	if (tab->size == 1 && ft_is_inbuilt(cmd))

--- a/execution/process_execution.c
+++ b/execution/process_execution.c
@@ -6,7 +6,7 @@
 /*   By: aldokezer <aldokezer@student.42.fr>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/02 12:35:56 by aldokezer         #+#    #+#             */
-/*   Updated: 2024/04/08 17:58:56 by aldokezer        ###   ########.fr       */
+/*   Updated: 2024/04/18 11:44:09 by aldokezer        ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -84,6 +84,12 @@ void	ft_exec_input(t_cmd_tab *tab, t_mini_data *minidata)
 // By now we have opened 5 file descriptors that are connected to 3 files
 	ft_init_exec_data(&data);
 	cmd = tab->first_cmd;
+
+	pid_t *child_pids;       // Array to store child PIDs
+    int num_children;
+	int num_commands = tab->size;
+	child_pids = malloc(sizeof(pid_t) * num_commands);
+	num_children = 0;
 	while (cmd)
 	{
 		if(cmd->next != NULL)
@@ -98,6 +104,7 @@ void	ft_exec_input(t_cmd_tab *tab, t_mini_data *minidata)
 		}
 		else
 		{
+			child_pids[num_children++] = pid;
 			if (data.fd_in != STDIN_FILENO)
 				close(data.fd_in);
 			if (cmd->next != NULL)
@@ -108,5 +115,23 @@ void	ft_exec_input(t_cmd_tab *tab, t_mini_data *minidata)
 		}
 		cmd = cmd->next;
 	}
-	ft_parent_process(&data, minidata, pid);
+	int	status;
+
+	status = 0;
+	// waitpid(pid, &status, 0);
+	//int status;
+
+    for (int i = 0; i < num_children; i++)
+	{
+        waitpid(child_pids[i], &status, 0);
+        ft_update_exit_status(&status, minidata);
+    }
+	//ft_update_exit_status(&status, minidata);
+	close(data.ori_fd_in);
+	close(data.ori_fd_out);
+	//ft_parent_process(&data, minidata, pid);
 }
+
+		// int status;
+		// pid_t child_pid;
+		// child_pid = waitpid(-1, &status, 0);

--- a/minishell.h
+++ b/minishell.h
@@ -6,7 +6,7 @@
 /*   By: aldokezer <aldokezer@student.42.fr>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/02 16:24:52 by aldokezer         #+#    #+#             */
-/*   Updated: 2024/04/18 10:05:31 by aldokezer        ###   ########.fr       */
+/*   Updated: 2024/04/18 11:47:33 by aldokezer        ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -281,6 +281,9 @@ void	ft_cmd_error(t_cmd *cmd);
 void	ft_parent_process(t_exec_data *data, t_mini_data *minidata, pid_t pid);
 void	ft_init_exec_data(t_exec_data *exec_data);
 void	ft_exit_status(int *status);
+
+// exit status
+void	ft_update_exit_status(int *status, t_mini_data *minidata);
 
 // error exec functions
 int		ft_is_path_valid(const char *path);

--- a/minishell.h
+++ b/minishell.h
@@ -6,7 +6,7 @@
 /*   By: aldokezer <aldokezer@student.42.fr>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/02 16:24:52 by aldokezer         #+#    #+#             */
-/*   Updated: 2024/04/18 11:47:33 by aldokezer        ###   ########.fr       */
+/*   Updated: 2024/04/18 21:32:12 by aldokezer        ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -105,6 +105,11 @@ typedef struct s_exec_data
 	int	ori_fd_in;
 	int	ori_fd_out;
 	int	pipe_fd[2];
+	int	num_children;
+	int	num_commands;
+	t_cmd	*cmd;
+	pid_t	pid;
+	pid_t	*child_pids;
 }		t_exec_data;
 
 // Enviromental vars structures
@@ -279,7 +284,7 @@ void	ft_execve(t_cmd *cmd, t_mini_data *minidata);
 void	ft_select_built_cmd(t_cmd *cmd, t_env_list env_list);
 void	ft_cmd_error(t_cmd *cmd);
 void	ft_parent_process(t_exec_data *data, t_mini_data *minidata, pid_t pid);
-void	ft_init_exec_data(t_exec_data *exec_data);
+void	ft_init_exec_data(t_exec_data *exec_data, t_cmd_tab *tab);
 void	ft_exit_status(int *status);
 
 // exit status


### PR DESCRIPTION
Fixing process execution to be concurrent. Commands such as cat | ls or cat. Also fixing exit status when sigint is initiated.